### PR TITLE
fix: LIB Ordering  (aka DSO missing from command line)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ pwntcha_SOURCES = \
     test.c \
     $(NULL)
 pwntcha_CFLAGS = $(imaging_cflags) -Wall -O6
-pwntcha_LDFLAGS = $(imaging_ldflags)
+pwntcha_LDFLAGS = -lm $(imaging_ldflags)
 pwntcha_LDADD = $(SUBDIRS:%=%/libdecoder.a)
 
 if USE_SDL


### PR DESCRIPTION
In a number of cases the math library will be imported in the
wrong order.  In general the math library should supercede any
libraries loaded by pwntcha.

Fixes iveney/pwntcha/#7
