### PR TITLE
update bootstrap for newer versions of automake

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,9 +1,8 @@
 #! /bin/sh
-# $Id: bootstrap 1966 2008-02-17 08:29:51Z sam $
 
 # bootstrap: generic bootstrap/autogen.sh script for autotools projects
 #
-# Copyright (c) 2002-2008 Sam Hocevar <sam@zoy.org>
+# Copyright (c) 2002-2011 Sam Hocevar <sam@hocevar.net>
 #
 #    This program is free software. It comes without any warranty, to
 #    the extent permitted by applicable law. You can redistribute it
@@ -12,7 +11,7 @@
 #    http://sam.zoy.org/wtfpl/COPYING for more details.
 #
 # The latest version of this script can be found at the following place:
-#   http://sam.zoy.org/autotools/
+#    http://caca.zoy.org/wiki/build
 
 # Die if an error occurs
 set -e
@@ -29,13 +28,15 @@ fi
 
 # Check for needed features
 auxdir="`sed -ne 's/^[ \t]*A._CONFIG_AUX_DIR *([[ ]*\([^] )]*\).*/\1/p' $conffile`"
-libtool="`grep -q '^[ \t]*A._PROG_LIBTOOL' $conffile && echo yes || echo no`"
-header="`grep -q '^[ \t]*A._CONFIG_HEADER' $conffile && echo yes || echo no`"
-aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am`"
+pkgconfig="`grep '^[ \t]*PKG_PROG_PKG_CONFIG' $conffile >/dev/null 2>&1 && echo yes || echo no`"
+libtool="`grep '^[ \t]*A._PROG_LIBTOOL' $conffile >/dev/null 2>&1 && echo yes || echo no`"
+header="`grep '^[ \t]*A._CONFIG_HEADER' $conffile >/dev/null 2>&1 && echo yes || echo no`"
+makefile="`[ -f Makefile.am ] && echo yes || echo no`"
+aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am 2>/dev/null || :`"
 
 # Check for automake
 amvers="no"
-for v in 11 10 9 8 7 6 5; do
+for v in $(seq 100 -1 5); do
   if automake-1.${v} --version >/dev/null 2>&1; then
     amvers="-1.${v}"
     break
@@ -93,6 +94,14 @@ if test "$libtool" = "yes"; then
   fi
 fi
 
+# Check for pkg-config
+if test "$pkgconfig" = "yes"; then
+  if ! pkg-config --version >/dev/null 2>&1; then
+    echo "$0: you need pkg-config"
+    exit 1
+  fi
+fi
+
 # Remove old cruft
 for x in aclocal.m4 configure config.guess config.log config.sub config.cache config.h.in config.h compile libtool.m4 ltoptions.m4 ltsugar.m4 ltversion.m4 ltmain.sh libtool ltconfig missing mkinstalldirs depcomp install-sh; do rm -f $x autotools/$x; if test -n "$auxdir"; then rm -f "$auxdir/$x"; fi; done
 rm -Rf autom4te.cache
@@ -102,6 +111,17 @@ if test -n "$auxdir"; then
   fi
   aclocalflags="${aclocalflags} -I $auxdir -I ."
 fi
+
+# Honour M4PATH because sometimes M4 doesn't
+save_IFS=$IFS
+IFS=:
+tmp="$M4PATH"
+for x in $tmp; do
+  if test -n "$x"; then
+    aclocalflags="${aclocalflags} -I $x"
+  fi
+done
+IFS=$save_IFS
 
 # Explain what we are doing from now
 set -x
@@ -120,9 +140,11 @@ autoconf${acvers}
 if test "$header" = "yes"; then
   autoheader${acvers}
 fi
-#add --include-deps if you want to bootstrap with any other compiler than gcc
-#automake${amvers} --add-missing --copy --include-deps
-automake${amvers} --foreign --add-missing --copy
+if test "$makefile" = "yes"; then
+  #add --include-deps if you want to bootstrap with any other compiler than gcc
+  #automake${amvers} --add-missing --copy --include-deps
+  automake${amvers} --foreign --add-missing --copy
+fi
 
 # Remove cruft that we no longer want
 rm -Rf autom4te.cache


### PR DESCRIPTION
first i updated to the latest version of sam's bootstrap available from http://caca.zoy.org/wiki/build , then, because both the latest version, and the 2008 version from this repo, both has a bug that incorrectly detects automake version 1.12 and higher (like version 1.15, which is the latest release as of speaking) as being below version 1.5, which is the hardcoded minimum version, i added a quick dirty hack on line 39 to correctly detect version 1.100 to 1.5 - it will break again when bootstrap version 1.101 or 2.0 comes out, but it will probably be years..