### PR TITLE
include math.h for sqrt

### DIFF
--- a/src/livejournal/decoder.c
+++ b/src/livejournal/decoder.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <math.h>
 
 #include "config.h"
 #include "common.h"


### PR DESCRIPTION
i believe gcc has historically just silently and implicitly included this header when needed, but at least in gcc 7.2, it will *complain* (not fail compilation, but complain)  that you're using sqrt without including math.h - which is supposed to be included for using the function anyway.