### PR TITLE
remove dependency on dl() for portability

### DIFF
--- a/extras/font_linuxfr.php
+++ b/extras/font_linuxfr.php
@@ -1,5 +1,11 @@
 <?php
-   dl("gd.so");
+   if (!extension_loaded('gd')) {
+       if (!is_callable("dl") || !dl('gd.so')) {
+           http_response_code(500);
+           echo "this script requires the gd extension, which is neither loaded nor loadable";
+           exit;
+       }
+   }
    header("Content-type: image/png");
    $s = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
    $im = imagecreate(strlen($s) * 9, 12);
@@ -8,4 +14,3 @@
    imagestring($im, 5, 0, -3,  $s, $fg);
    imagepng($im);
    imagedestroy($im);
-?> 


### PR DESCRIPTION
this makes the script significantly more portable, the dl() function has been removed from pretty much everywhere except cli, and makes a fatal error when being called. now we only try to call it if gd is not already loaded, and dl is actually callable